### PR TITLE
Replace cpp with core2 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-![Microsoft Defending Democracy Program: ElectionGuard Python][banner image]
+![Microsoft Defending Democracy Program: ElectionGuard Core2][banner image]
 
-# 🗳 ElectionGuard C++
+# 🗳 ElectionGuard Core2
 
-[![ElectionGuard Specification 0.95.0](https://img.shields.io/badge/🗳%20ElectionGuard%20Specification-0.95.0-green)](https://www.electionguard.vote) ![Github Package Action](https://github.com/microsoft/electionguard-cpp/workflows/Release/badge.svg) [![license](https://img.shields.io/github/license/microsoft/electionguard-cpp)](https://github.com/microsoft/electionguard-cpp/blob/main/LICENSE) [![license](https://img.shields.io/nuget/v/Electionguard.Encryption)](https://www.nuget.org/packages/ElectionGuard.Encryption/)
+[![ElectionGuard Specification 1.1.0](https://img.shields.io/badge/🗳%20ElectionGuard%20Specification-1.1.0-green)](https://www.electionguard.vote) ![Github Package Action](https://github.com/microsoft/electionguard-core2/workflows/Release/badge.svg) [![license](https://img.shields.io/github/license/microsoft/electionguard-core2)](https://github.com/microsoft/electionguard-core2/blob/main/LICENSE) [![license](https://img.shields.io/nuget/v/Electionguard.Encryption)](https://www.nuget.org/packages/ElectionGuard.Encryption/)
 
-This repository is a "reference implementation" of an ElectionGuard ballot encryption library written in c++ and includes a C-compatible API for referencing the library from pure-c application. This core SDK performs ballot encryption and verification functions and is suitable for execution on voting system hardware and low powered devices. It is designed to be integrated into existing (or new) voting system software.
+This monorepo contains the ElectionGuard 2.0+ code. The core functionality is implemented in C++ for performance and interoperability. It provides functionality for all ElectionGuard workflows including key ceremony, ballot encryption, tally, ballot decryption, and verification. It is designed to be integrated into existing (or new) voting system software. It includes a variety of interop layers to provide functionality to languages including C, .NET, and Java.
 
 This repository is `pre-release` software to showcase the ElectionGuard API implemented in a native language. It is not feature complete and should not be used for production applications.
 
 ## 📁 In This Repository
 
-| File/folder                            | Description                                |
-| -------------------------------------  | ------------------------------------------ |
-| [`.github`](.github)                   | Github workflows and issue templates       |
-| [`.vscode`](.vscode)                   | VS Code configurations                     |
-| [`/bindings`](/bindings)               | Binding interfaces for different languages |
-| [`/cmake`](/cmake)                     | `CMake` dependencies`                      |
-| [`/include`](/include)                 | Public include headers                     |
-| [`/src`](/src)                         | ElectionGuard source code                  |
-| [`/test`](/test)                       | Unit tests                                 |
-| [`.clang-format`](.clang-format)       | Style guidelines                           |
-| [`.gitignore`](.gitignore)             | Define what to ignore at commit time.      |
-| [`CMakeLists.txt`](CMakeLists.txt)     | Root CMake file                            |
-| [`CONTRIBUTING.md`](CONTRIBUTING.md)   | Guidelines for contributing to the sample. |
-| [`README.md`](README.md)               | This README file.                          |
-| [`LICENSE`](LICENSE)                   | The license for the sample.                |
+| File/folder                          | Description                                |
+| ------------------------------------ | ------------------------------------------ |
+| [`.github`](.github)                 | Github workflows and issue templates       |
+| [`.vscode`](.vscode)                 | VS Code configurations                     |
+| [`/bindings`](/bindings)             | Binding interfaces for different languages |
+| [`/cmake`](/cmake)                   | `CMake` dependencies`                      |
+| [`/include`](/include)               | Public include headers                     |
+| [`/src`](/src)                       | ElectionGuard source code                  |
+| [`/test`](/test)                     | Unit tests                                 |
+| [`.clang-format`](.clang-format)     | Style guidelines                           |
+| [`.gitignore`](.gitignore)           | Define what to ignore at commit time.      |
+| [`CMakeLists.txt`](CMakeLists.txt)   | Root CMake file                            |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Guidelines for contributing to the sample. |
+| [`README.md`](README.md)             | This README file.                          |
+| [`LICENSE`](LICENSE)                 | The license for the sample.                |
 
 ## ❓ What Is ElectionGuard?
 
@@ -218,7 +218,7 @@ make test-netstandard
 
 To run the tests when building for a mobile device, you can run the .Net Standard tests using the Xamarin Test runner on the Android Emulator or the iOS simulator:
 
-**NOTE: Xamarin build support is temporarily disabled while the project migrates to the new SDK style project format.**  Please refer to ISSUE #195 for more information.
+**NOTE: Xamarin build support is temporarily disabled while the project migrates to the new SDK style project format.** Please refer to ISSUE #195 for more information.
 
 ```sh
 make build-netstandard
@@ -256,6 +256,10 @@ A huge thank you to those who helped to contribute to this project so far, inclu
 
 <a href="https://www.microsoft.com/en-us/research/people/benaloh/"><img src="https://www.microsoft.com/en-us/research/wp-content/uploads/2016/09/avatar_user__1473484671-180x180.jpg" title="Josh Benaloh" width="80" height="80"></a>
 
+**[Steve Maier](https://github.com/SteveMaier-IRT) [_(InfernoRed Technology)_](https://infernored.com/)**
+
+<a href="https://github.com/SteveMaier-IRT"><img src="https://avatars2.githubusercontent.com/u82616727?v=4" title="SteveMaier-IRT" width="80" height="80"></a>
+
 **[Keith Fung](https://github.com/keithrfung) [_(InfernoRed Technology)_](https://infernored.com/)**
 
 <a href="https://github.com/keithrfung"><img src="https://avatars2.githubusercontent.com/u/10125297?v=4" title="keithrfung" width="80" height="80"></a>
@@ -284,6 +288,6 @@ A huge thank you to those who helped to contribute to this project so far, inclu
 
 [banner image]: https://raw.githubusercontent.com/microsoft/electionguard-python/main/images/electionguard-banner.svg
 [pull request workflow]: https://github.com/microsoft/electionguard-ccpp/blob/main/.github/workflows/pull_request.yml
-[contributing]: https://github.com/microsoft/electionguard-cpp/blob/main/CONTRIBUTING.md
-[security]: https://github.com/microsoft/electionguard-cpp/blob/main/SECURITY.md
-[mit license]: https://github.com/microsoft/electionguard-cpp/blob/main/LICENSE
+[contributing]: https://github.com/microsoft/electionguard-core2/blob/main/CONTRIBUTING.md
+[security]: https://github.com/microsoft/electionguard-core2/blob/main/SECURITY.md
+[mit license]: https://github.com/microsoft/electionguard-core2/blob/main/LICENSE

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
@@ -21,8 +21,8 @@
     <Authors>Microsoft</Authors>
     <PackageVersion>1.0.1</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/microsoft/electionguard-cpp</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/microsoft/electionguard-cpp</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/electionguard-core2</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/microsoft/electionguard-core2</RepositoryUrl>
     <PackageTags>Microsoft;Electionguard;Encryption;Windows;MacOS;Linux</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>

--- a/docs/Design_and_Architecture.md
+++ b/docs/Design_and_Architecture.md
@@ -1,26 +1,26 @@
 # Design & Architecture
 
-This page describes the design and architecture of the `electionguard-cpp` project.
+This page describes the design and architecture of the `electionguard-core2` project.
 
 ## Design
 
-This C++ project only implements a subset of the full ElectionGuard specification.  The C++ implementation is designed solely to support ballot encryption and verification on "lower powered" hardware.  This library only implements the objects and functions necessary to generate and verify ballots.
+This C++ project only implements a subset of the full ElectionGuard specification. The C++ implementation is designed solely to support ballot encryption and verification on "lower powered" hardware. This library only implements the objects and functions necessary to generate and verify ballots.
 
 ### ✅ Cross Platform
 
-One goal of this project is to be able to run on as many platforms as possible.  The CI pipeline is configured across a variety of common platforms and compilers, but if there is something missing, please open an issue.
+One goal of this project is to be able to run on as many platforms as possible. The CI pipeline is configured across a variety of common platforms and compilers, but if there is something missing, please open an issue.
 
 ### ✅ Modern Tools
 
-This project uses C++17 and requires a compiler capable of interpreting the C++17 specification.  A public C API is included to consume the library from C code, but a C++ compiler is still required.
+This project uses C++17 and requires a compiler capable of interpreting the C++17 specification. A public C API is included to consume the library from C code, but a C++ compiler is still required.
 
 ### ✅ Extensibility
 
-The library is intentionally general to support the multiple use cases of end to end verifiable voting systems. Different projects may wish to use different layers of the library, including math primitives, encryption functions, and more.  The library exposes a C++ Interface as well as a C Interface; both are treated as first-class citizens.  Binding layers are also provided to simplify consuming the library from other languages.
+The library is intentionally general to support the multiple use cases of end to end verifiable voting systems. Different projects may wish to use different layers of the library, including math primitives, encryption functions, and more. The library exposes a C++ Interface as well as a C Interface; both are treated as first-class citizens. Binding layers are also provided to simplify consuming the library from other languages.
 
 ### ✅ Object Oriented Design (OOD) & Functional Methods
 
-An additional goal of this effort is to structure the code using familiar object-oriented design patterns while exposing underlying immutable and functional-style methods. Higher-order functions are also included to simplify using the library for common use cases.  This allows users to both construct high-level objects in an OOP fashion and pass them to a single function call (such as `encryptBallot`), or compose a domain-specific object graph and directly call the underlying methods in a functional way (such as `encryptSelection`). 
+An additional goal of this effort is to structure the code using familiar object-oriented design patterns while exposing underlying immutable and functional-style methods. Higher-order functions are also included to simplify using the library for common use cases. This allows users to both construct high-level objects in an OOP fashion and pass them to a single function call (such as `encryptBallot`), or compose a domain-specific object graph and directly call the underlying methods in a functional way (such as `encryptSelection`).
 
 Class methods are used for simplicity, but sophistication with regard to inheritance, object encapsulation, or design patterns is intentionally avoided. These class methods usually rely on the aforementioned functional methods unless the class contains state.
 
@@ -32,15 +32,15 @@ The library prefers immutable objects where possible to encourage simple data st
 
 ### ✅ Concurrency
 
-While this library is not yet explicitly guaranteed to be _thread-safe_, it's definitely meant to work properly when the caller wants to run more than one thing at a time. This means there is intentionally minimal global, mutable state in the library.  If global mutable state is added, such as a discrete-log function doing internal memoization, thread safety will be considered.
+While this library is not yet explicitly guaranteed to be _thread-safe_, it's definitely meant to work properly when the caller wants to run more than one thing at a time. This means there is intentionally minimal global, mutable state in the library. If global mutable state is added, such as a discrete-log function doing internal memoization, thread safety will be considered.
 
 ### ✅ Exceptions
 
-This library uses exceptions internally, and public C++ API's may throw exceptions.  When consuming the library using the C Interface, return-code enumerations are used to communicate success or failure.
+This library uses exceptions internally, and public C++ API's may throw exceptions. When consuming the library using the C Interface, return-code enumerations are used to communicate success or failure.
 
 ### ✅ Safety
 
-This project attempts to use modern C++ features and tools to catch memory issues at compile time and during release cycles.  Smart Pointers and move semantics are used throughout to help the consumer understand when the caller is responsible for managing object lifecycles.  The CI/CD pipelines also run static and dynamic analysis to help catch leaks.  Because of the nuances across targets, processor architectures, toolchains, and operating systems, it is possible gaps exist on some platforms.  Please open an issue if a gap is found.
+This project attempts to use modern C++ features and tools to catch memory issues at compile time and during release cycles. Smart Pointers and move semantics are used throughout to help the consumer understand when the caller is responsible for managing object lifecycles. The CI/CD pipelines also run static and dynamic analysis to help catch leaks. Because of the nuances across targets, processor architectures, toolchains, and operating systems, it is possible gaps exist on some platforms. Please open an issue if a gap is found.
 
 ### 🚫 Multiple Inheritance
 
@@ -50,7 +50,7 @@ Although a handy C++ feature, for implementation simplicity this feature is not 
 
 ### 🚀 Continuous Integration
 
-Github actions are used to execute a variety of tools and tests across a broad spectrum of targets to help maintain cross-platform compatibility.  Because of this, certain targets can only be executed on certain operating systems easily (e.g. iOS).  The CI pipeline runs on every pull request.
+Github actions are used to execute a variety of tools and tests across a broad spectrum of targets to help maintain cross-platform compatibility. Because of this, certain targets can only be executed on certain operating systems easily (e.g. iOS). The CI pipeline runs on every pull request.
 
 ### 🧹 Clean Code
 
@@ -58,7 +58,7 @@ The library uses several tools to assist developers in maintaining clean code. [
 
 #### Typing
 
-This library uses both complete and opaque types depending on the circumstances.  Where possible, all objects consumed and returned across the C++ API are complete types.  Internally the C++ header files use opaque class types to implement the `pimpl` idiom.  The types used by the C API are completely opaque.
+This library uses both complete and opaque types depending on the circumstances. Where possible, all objects consumed and returned across the C++ API are complete types. Internally the C++ header files use opaque class types to implement the `pimpl` idiom. The types used by the C API are completely opaque.
 
 #### Formatting
 
@@ -66,7 +66,7 @@ This library uses both complete and opaque types depending on the circumstances.
 
 #### Linting
 
-Linting is handled by compiler flags, clang tidy, and cpp check.  Check out the root `CMakeLists.txt` and `tools.cmake` for more information.
+Linting is handled by compiler flags, clang tidy, and cpp check. Check out the root `CMakeLists.txt` and `tools.cmake` for more information.
 
 ### 🧪 Testing
 
@@ -76,15 +76,15 @@ The goal of the project is 100% code coverage with an understanding that there a
 
 ### Layout
 
-This project aims to use structural patterns similar to the Python repository.  While it is not a direct port, many of the interfaces and paradigms found in the Python library also apply to this project.
+This project aims to use structural patterns similar to the Python repository. While it is not a direct port, many of the interfaces and paradigms found in the Python library also apply to this project.
 
 ### 📦 Math Library
 
-This project uses the [HACL* Math Library](https://github.com/project-everest/hacl-star) from [Project Everest](https://project-everest.github.io/) for low-level math operations.  The low-level math operations are not exposed across any public API surface at this time. We are indebted to both Jonathan Protsenko (@protz) and Marina Polubelova (@polubelova) for their help supporting this important ElectionGuard initiative.  
+This project uses the [HACL\* Math Library](https://github.com/project-everest/hacl-star) from [Project Everest](https://project-everest.github.io/) for low-level math operations. The low-level math operations are not exposed across any public API surface at this time. We are indebted to both Jonathan Protsenko (@protz) and Marina Polubelova (@polubelova) for their help supporting this important ElectionGuard initiative.
 
 ### Linking
 
-This library is generally consumable as static library or as a dynamic library but there may be some limitations depending on the platform target.  Additionally, dependencies may be static or dynamic depending on the target.
+This library is generally consumable as static library or as a dynamic library but there may be some limitations depending on the platform target. Additionally, dependencies may be static or dynamic depending on the target.
 
 ### Object Lifecycle
 
@@ -92,17 +92,18 @@ If you have any questions about consuming objects from this library, please [che
 
 #### C++ API Lifecycle
 
-The C++ API is based on smart pointers that demonstrate intention to the consumer how to consider lifecycle.  Move semantics are used throughout.  All public-facing C++ objects can be constructed directly, however some objects include special `make` functions that are used in a similar fashion to the Python library.  Standard library types and primitive types are usually copied when constructing new objects, while domain types are usually moved.  The intended behavior should be well-defined depending whether a property is passed by reference or by value.
+The C++ API is based on smart pointers that demonstrate intention to the consumer how to consider lifecycle. Move semantics are used throughout. All public-facing C++ objects can be constructed directly, however some objects include special `make` functions that are used in a similar fashion to the Python library. Standard library types and primitive types are usually copied when constructing new objects, while domain types are usually moved. The intended behavior should be well-defined depending whether a property is passed by reference or by value.
 
 We endeavor to follow the [Rule of Five](https://cpppatterns.com/patterns/rule-of-five.html), however this is not always guaranteed.
 
-When accessing properties of structures, a _raw pointer_ may be returned to indicate the caller does not own the object (e.g. `ElementModQ *getCryptoHash()`), while a Smart pointer is returned if the object is owned (e.g. `std::unique_ptr<ElementModQ> crypto_hash_with`) by the caller.  The [std::reference_wrapper](https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper) is used when returning vectors of objects owned by the callee (e.g. `std::vector<std::reference_wrapper<PlaintextBallotSelection>> getSelections()`).  
+When accessing properties of structures, a _raw pointer_ may be returned to indicate the caller does not own the object (e.g. `ElementModQ *getCryptoHash()`), while a Smart pointer is returned if the object is owned (e.g. `std::unique_ptr<ElementModQ> crypto_hash_with`) by the caller. The [std::reference_wrapper](https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper) is used when returning vectors of objects owned by the callee (e.g. `std::vector<std::reference_wrapper<PlaintextBallotSelection>> getSelections()`).
 
 #### C API Lifecycle
 
-Because the C API does not support smart pointers, consideration is given to using `make` functions where an object graph may be composed (analogous to the `make` functions in the C++ API and in python).  Some structures include `new` methods as well to construct primitive objects directly.  C types also generally include `free` methods to release resources.  _Property getter_ methods usually include `get` in the function signature (e.g. `_get_description_hash`). Because the C API is a facade over the C++ API, careful consideration must be given to freeing resources.
+Because the C API does not support smart pointers, consideration is given to using `make` functions where an object graph may be composed (analogous to the `make` functions in the C++ API and in python). Some structures include `new` methods as well to construct primitive objects directly. C types also generally include `free` methods to release resources. _Property getter_ methods usually include `get` in the function signature (e.g. `_get_description_hash`). Because the C API is a facade over the C++ API, careful consideration must be given to freeing resources.
 
 Generally:
+
 1. If you built your object graph manually using `new` then you must call `free` on each object you constructed. (such as an array of `eg_selection_description_t[]`).
 2. If you built your object graph using `make` or an out parameter was passed by function, you must only call `free` on the top-level object.
 3. If the corresponding c++ returns a `unique_ptr` to a domain type then it is owned by the caller and must be freed.
@@ -135,7 +136,7 @@ if (eg_element_mod_q_to_hex(crypto_base_hash, &crypto_base_hash_hex)) {
 
 // Clean Up resources
 free(crypto_base_hash_hex);                     // clean up the string that we malloc'd
-eg_ciphertext_election_context_free(result);    // clean up the object we created   
+eg_ciphertext_election_context_free(result);    // clean up the object we created
 eg_element_mod_q_free(crypto_base_hash);        // ERROR! Use after free
 
 ```


### PR DESCRIPTION
### Issue

Fixes #1

### Description
Replaces references to cpp with core2 in documentation.

### Testing
na