### PR TITLE
Moved to the CiphertextBallot and removed the deprecated one

### DIFF
--- a/src/electionguard-ui/ElectionGuard.UI/ViewModels/BallotUploadViewModel.cs
+++ b/src/electionguard-ui/ElectionGuard.UI/ViewModels/BallotUploadViewModel.cs
@@ -130,7 +130,7 @@ public partial class BallotUploadViewModel : BaseViewModel
             {
                 var filename = Path.GetFileName(currentBallot);
                 var ballotData = File.ReadAllText(currentBallot);
-                SubmittedBallot ballot = new(ballotData);
+                CiphertextBallot ballot = new(ballotData);
 
                 if (ballot.ManifestHash != _manifestHash)
                 {

--- a/src/electionguard-ui/ElectionGuard.UI/ViewModels/CreateKeyCeremonyAdminViewModel.cs
+++ b/src/electionguard-ui/ElectionGuard.UI/ViewModels/CreateKeyCeremonyAdminViewModel.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.Input;
+﻿using CommunityToolkit.Mvvm.Input;
 using ElectionGuard.UI.Lib.Models;
 
 namespace ElectionGuard.UI.ViewModels;
@@ -40,7 +40,7 @@ public partial class CreateKeyCeremonyAdminViewModel : BaseViewModel
             return;
         }
 
-        var keyCeremony = new KeyCeremonyRecord(KeyCeremonyName, Quorum, NumberOfGuardians, this.UserName!);
+        var keyCeremony = new KeyCeremonyRecord(KeyCeremonyName, NumberOfGuardians, Quorum, this.UserName!);
         var ret = await _keyCeremonyService.SaveAsync(keyCeremony);
         var keyCeremonyId = ret.KeyCeremonyId!;
         await NavigationService.GoToPage(typeof(ViewKeyCeremonyViewModel), new Dictionary<string, object>


### PR DESCRIPTION
Fixed the order of the number of guardians and quorum for creating a new key ceremony

### Issue
Fixes #227 

### Description
Reorders the fields for creating a key ceremony.

### Testing

