### PR TITLE
Allow null BallotSubTitle and contact info

### DIFF
--- a/src/electionguard/manifest.cpp
+++ b/src/electionguard/manifest.cpp
@@ -1115,12 +1115,20 @@ namespace electionguard
             }
 
             // TODO: handle optional values
-            if (ballotTitle != nullptr) {
+            if (ballotTitle != nullptr && ballotSubtitle != nullptr) {
                 auto hash = hash_elems({object_id, sequenceOrder, electoralDistrictId,
                                         getVoteVariationTypeString(voteVariation),
                                         ref<CryptoHashable>(*ballotTitle),
                                         ref<CryptoHashable>(*ballotSubtitle), name, numberElected,
                                         votesAllowed, selectionRefs});
+                Log::trace("ContestDescription", hash.get());
+                return hash;
+            }
+            if (ballotTitle != nullptr) {
+                auto hash = hash_elems({object_id, sequenceOrder, electoralDistrictId,
+                                        getVoteVariationTypeString(voteVariation),
+                                        ref<CryptoHashable>(*ballotTitle), nullptr, name,
+                                        numberElected, votesAllowed, selectionRefs});
                 Log::trace("ContestDescription", hash.get());
                 return hash;
             }
@@ -1530,6 +1538,14 @@ namespace electionguard
                    timePointToIsoString(endDate), nullptr, nullptr, geopoliticalUnitRefs, partyRefs,
                    contestRefs, ballotStyleRefs});
                 Log::trace("Manifest:: NO NAME!", hash->toHex());
+                return hash;
+            }
+
+            if (contactInformation == nullptr) {
+                auto hash = hash_elems(
+                  {electionScopeId, getElectionTypeString(type), timePointToIsoString(startDate),
+                   timePointToIsoString(endDate), ref<CryptoHashable>(*name), nullptr,
+                   geopoliticalUnitRefs, partyRefs, contestRefs, ballotStyleRefs});
                 return hash;
             }
 

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -116,6 +116,10 @@ namespace electionguard
 
     static unique_ptr<ContactInformation> contactInformationFromJson(const json &j)
     {
+        if (j.is_null()) {
+            return nullptr;
+        }
+
         vector<string> addressLine;
         if (j.contains("address_line") && !j["address_line"].is_null()) {
             for (const auto &i : j["address_line"]) {


### PR DESCRIPTION
### Issue
Fixes #241 
Fixes #242 

### Description
Add support for importing manifest files that have some of the fields set as null.

### Testing
Load manifest with null contactinformation or ballotSubtilte