### PR TITLE
Adding unzip to the build environment for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ ifeq ($(OPERATING_SYSTEM),Linux)
 	sudo apt install -y clang-tidy
 	sudo apt install -y ninja-build
 	sudo apt install -y valgrind
+	sudo apt install -y unzip
 endif
 ifeq ($(OPERATING_SYSTEM),Windows)
 	@echo 🏁 WINDOWS INSTALL


### PR DESCRIPTION
#253

### Issue
Fixes #253 

### Description
Added unzip to be installed on the linux build environment step

### Testing
On Ubuntu, either have a version where unzip is not installed yet, or uninstall it.  Run the build environment command and then  unzip should be installed.