### PR TITLE
Added the func for the timer

### DIFF
--- a/src/electionguard-ui/ElectionGuard.UI/ViewModels/GuardianHomeViewModel.cs
+++ b/src/electionguard-ui/ElectionGuard.UI/ViewModels/GuardianHomeViewModel.cs
@@ -23,7 +23,9 @@ public partial class GuardianHomeViewModel : BaseViewModel
     {
         await base.OnAppearing();
 
+        _timer.Tick += PollingTimer_Tick;
         _timer.Start();
+
         PollingTimer_Tick(this, null);
     }
 


### PR DESCRIPTION
### Issue
Fixes #263

### Description
Added the method to the timer to do the refreshing

### Testing
start an admin and a guardian in separate instances of the app, have the admin add a new tally for an election that the guardian is a part of, the guardian homescreen should update within 5 seconds to show the new tally.