### PR TITLE
add create election to the CLI tool

### DIFF
--- a/apps/electionguard-cli/Create/CreateElectionCommand.cs
+++ b/apps/electionguard-cli/Create/CreateElectionCommand.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+
+namespace ElectionGuard.CLI.Encrypt
+{
+    internal class CreateElectionCommand
+    {
+        public static Task Execute(CreateElectionOptions options)
+        {
+            try
+            {
+                var command = new CreateElectionCommand();
+                return command.ExecuteInternal(options);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        private Task ExecuteInternal(CreateElectionOptions options)
+        {
+            Console.WriteLine("Create Election");
+
+            options.Validate();
+
+            if (string.IsNullOrEmpty(options.Manifest))
+            {
+                throw new ArgumentNullException(nameof(options.Manifest));
+            }
+
+            Console.WriteLine($"Loading Manifest {options.Manifest}");
+
+            // load the manifest
+            var manifestJson = File.ReadAllText(options.Manifest);
+
+            Console.WriteLine("Loading Manifest");
+
+            var manifest = new Manifest(manifestJson);
+
+            Console.WriteLine("Loading Internal Manifest");
+
+            var internalManifest = new InternalManifest(manifest);
+
+            Console.WriteLine("Loading Context");
+
+            var commitmentHash = new ElementModQ(options.CommitmentHash);
+            var publicKey = new ElementModP(options.ElGamalPublicKey);
+
+            var context = new CiphertextElectionContext(
+                (ulong)options.NumberOfGuardians, (ulong)options.Quorum,
+                publicKey, commitmentHash, internalManifest.ManifestHash);
+
+            Console.WriteLine("Saving Files");
+
+            // write the files to the output directory
+            File.WriteAllText(Path.Join(options.OutDir, "context.json"), context.ToJson());
+            File.WriteAllText(Path.Join(options.OutDir, "manifest.json"), manifest.ToJson());
+
+
+            Console.WriteLine("Create Election Complete");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/apps/electionguard-cli/Create/CreateElectionOptions.cs
+++ b/apps/electionguard-cli/Create/CreateElectionOptions.cs
@@ -1,0 +1,57 @@
+using CommandLine;
+
+namespace ElectionGuard.CLI.Encrypt;
+
+[Verb("create-election", HelpText = "Create an Election Package.")]
+internal class CreateElectionOptions
+{
+    [Option('c', "commitment", Required = true, HelpText = "The commitment hash that guardians make to each other to complete the key ceremony.")]
+    public string CommitmentHash { get; set; }
+
+    [Option('m', "manifest", Required = true, HelpText = "Json file containing an ElectionGuard manifest that contains election details.")]
+    public string Manifest { get; set; }
+
+    [Option('g', "guardians", Required = true, HelpText = "The number of Guardians")]
+    public int NumberOfGuardians { get; set; }
+
+    [Option('q', "quorum", Required = true, HelpText = "The Quorum of guardians")]
+    public int Quorum { get; set; }
+
+    [Option('k', "publicKey", Required = true, Separator = ',', HelpText = "Elgamal public key of the key ceremony")]
+    public string ElGamalPublicKey { get; set; }
+
+    [Option('o', "out", Required = true, HelpText = "File folder in which to place encryption package.")]
+    public string? OutDir { get; set; }
+
+    public void Validate()
+    {
+        if (Quorum > NumberOfGuardians)
+        {
+            throw new ArgumentException("Quorum cannot be greater than the number of guardians");
+        }
+        ValidateDirectories();
+        ValidateFiles();
+    }
+
+    private void ValidateDirectories()
+    {
+        if (string.IsNullOrEmpty(OutDir))
+            throw new ArgumentNullException(nameof(OutDir));
+
+        if (!Directory.Exists(OutDir))
+        {
+            Console.WriteLine($"Creating directory: {OutDir}");
+            Directory.CreateDirectory(OutDir);
+        }
+    }
+
+    private void ValidateFiles()
+    {
+        var requiredFiles = new[] { Manifest };
+        var missingFiles = requiredFiles.Where(f => !File.Exists(f));
+        foreach (var file in missingFiles)
+        {
+            throw new ArgumentException($"{file} does not exist");
+        }
+    }
+}

--- a/apps/electionguard-cli/ElectionGuard.CLI.csproj
+++ b/apps/electionguard-cli/ElectionGuard.CLI.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="ElectionGuard.Encryption" Version="1.0.7" />
+    <PackageReference Include="ElectionGuard.Encryption" Version="1.75.10" />
   </ItemGroup>
 
   <PropertyGroup Label="Debug" Condition=" '$(Configuration)' == 'Debug' ">

--- a/apps/electionguard-cli/ElectionGuard.CLI.sln
+++ b/apps/electionguard-cli/ElectionGuard.CLI.sln
@@ -10,10 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectionGuard.CLI", "ElectionGuard.CLI.csproj", "{0771316F-7C71-4795-90DF-705EC63442ED}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectionGuard.Encryption", "..\..\bindings\netstandard\ElectionGuard\ElectionGuard.Encryption\ElectionGuard.Encryption.csproj", "{2D30F432-87CC-4210-8FC9-C33955E2B8C2}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectionGuard.Encryption.Utils", "..\..\bindings\netstandard\ElectionGuard\ElectionGuard.Encryption.Utils\ElectionGuard.Encryption.Utils.csproj", "{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|arm64 = Debug|arm64
@@ -36,30 +32,6 @@ Global
 		{0771316F-7C71-4795-90DF-705EC63442ED}.Release|x64.Build.0 = Release|x64
 		{0771316F-7C71-4795-90DF-705EC63442ED}.Release|x86.ActiveCfg = Release|x86
 		{0771316F-7C71-4795-90DF-705EC63442ED}.Release|x86.Build.0 = Release|x86
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Debug|arm64.ActiveCfg = Debug|arm64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Debug|arm64.Build.0 = Debug|arm64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Debug|x64.ActiveCfg = Debug|x64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Debug|x64.Build.0 = Debug|x64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Debug|x86.ActiveCfg = Debug|x86
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Debug|x86.Build.0 = Debug|x86
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Release|arm64.ActiveCfg = Release|arm64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Release|arm64.Build.0 = Release|arm64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Release|x64.ActiveCfg = Release|x64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Release|x64.Build.0 = Release|x64
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Release|x86.ActiveCfg = Release|x86
-		{2D30F432-87CC-4210-8FC9-C33955E2B8C2}.Release|x86.Build.0 = Release|x86
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Debug|arm64.ActiveCfg = Debug|arm64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Debug|arm64.Build.0 = Debug|arm64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Debug|x64.ActiveCfg = Debug|x64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Debug|x64.Build.0 = Debug|x64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Debug|x86.ActiveCfg = Debug|x86
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Debug|x86.Build.0 = Debug|x86
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Release|arm64.ActiveCfg = Release|arm64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Release|arm64.Build.0 = Release|arm64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Release|x64.ActiveCfg = Release|x64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Release|x64.Build.0 = Release|x64
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Release|x86.ActiveCfg = Release|x86
-		{DC458180-40A5-48D6-83E7-E4EAFA45D7F6}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,14 +42,5 @@ Global
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0
 		$0.TextStylePolicy = $3
-		$1.inheritsSet = null
-		$1.scope = application/x-msbuild
-		$0.XmlFormattingPolicy = $4
-		$2.inheritsSet = null
-		$2.scope = application/x-msbuild
-		$3.inheritsSet = null
-		$3.scope = application/xml
-		$4.scope = application/xml
-		$0.StandardHeader = $5
 	EndGlobalSection
 EndGlobal

--- a/apps/electionguard-cli/Encrypt/EncryptCommand.cs
+++ b/apps/electionguard-cli/Encrypt/EncryptCommand.cs
@@ -2,12 +2,12 @@
 {
     internal class EncryptCommand
     {
-        public static Task Encrypt(EncryptOptions encryptOptions)
+        public static Task Execute(EncryptOptions options)
         {
             try
             {
-                var encryptCommand = new EncryptCommand();
-                return encryptCommand.EncryptInternal(encryptOptions);
+                var command = new EncryptCommand();
+                return command.ExecuteInternal(options);
             }
             catch (Exception ex)
             {
@@ -16,28 +16,28 @@
             }
         }
 
-        private async Task EncryptInternal(EncryptOptions encryptOptions)
+        private async Task ExecuteInternal(EncryptOptions options)
         {
-            encryptOptions.Validate();
-            if (string.IsNullOrEmpty(encryptOptions.Context))
-                throw new ArgumentNullException(nameof(encryptOptions.Context));
-            if (string.IsNullOrEmpty(encryptOptions.Manifest))
-                throw new ArgumentNullException(nameof(encryptOptions.Manifest));
-            if (string.IsNullOrEmpty(encryptOptions.BallotsDir))
-                throw new ArgumentNullException(nameof(encryptOptions.BallotsDir));
+            options.Validate();
+            if (string.IsNullOrEmpty(options.Context))
+                throw new ArgumentNullException(nameof(options.Context));
+            if (string.IsNullOrEmpty(options.Manifest))
+                throw new ArgumentNullException(nameof(options.Manifest));
+            if (string.IsNullOrEmpty(options.BallotsDir))
+                throw new ArgumentNullException(nameof(options.BallotsDir));
 
             var encryptionMediator = await GetEncryptionMediator(
-                encryptOptions.Context, encryptOptions.Manifest);
-            var ballotFiles = GetBallotFiles(encryptOptions.BallotsDir);
+                options.Context, options.Manifest);
+            var ballotFiles = GetBallotFiles(options.BallotsDir);
 
             foreach (var ballotFile in ballotFiles)
             {
                 Console.WriteLine($"Parsing: {ballotFile}");
                 var plaintextBallot = await GetPlaintextBallot(ballotFile);
-                var spoiledDeviceIds = encryptOptions.SpoiledDeviceIds.ToList();
+                var spoiledDeviceIds = options.SpoiledDeviceIds.ToList();
                 var submittedBallot = EncryptAndSubmit(
                     encryptionMediator, plaintextBallot, spoiledDeviceIds, ballotFile);
-                await WriteSubmittedBallot(encryptOptions, ballotFile, submittedBallot);
+                await WriteSubmittedBallot(options, ballotFile, submittedBallot);
             }
             Console.WriteLine("Parsing Complete");
         }

--- a/apps/electionguard-cli/Program.cs
+++ b/apps/electionguard-cli/Program.cs
@@ -1,5 +1,7 @@
 ﻿using CommandLine;
 using ElectionGuard.CLI.Encrypt;
+using System;
+using System.Reflection;
 
 namespace ElectionGuard.CLI;
 
@@ -7,7 +9,28 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        await Parser.Default.ParseArguments<EncryptOptions>(args)
-            .WithParsedAsync(EncryptCommand.Encrypt);
+        var verbs = LoadVerbs();
+        await Parser.Default.ParseArguments(args, verbs)
+            .WithParsedAsync(Run);
+    }
+
+    //load all types using Reflection
+    private static Type[] LoadVerbs()
+    {
+        return Assembly.GetExecutingAssembly().GetTypes()
+            .Where(t => t.GetCustomAttribute<VerbAttribute>() != null).ToArray();
+    }
+
+    private static async Task Run(object obj)
+    {
+        switch (obj)
+        {
+            case CreateElectionOptions c:
+                CreateElectionCommand.Execute(c);
+                break;
+            case EncryptOptions o:
+                EncryptCommand.Execute(o);
+                break;
+        }
     }
 }

--- a/apps/electionguard-cli/README.md
+++ b/apps/electionguard-cli/README.md
@@ -16,7 +16,7 @@ make build-cli
 
 # test the command line tool
 cd /apps/electionguard-cli
-dotnet run -c ./path/to/context.json -m ./path/to/manifest.json -b ./path/to/plaintext-ballots -d ./path/to/device.json -o ./path/to/results
+dotnet run encrypt -c ./path/to/context.json -m ./path/to/manifest.json -b ./path/to/plaintext-ballots -d ./path/to/device.json -o ./path/to/results
 
 # pack the tool for local use
 dotnet pack


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Description
*Please describe your pull request.*

Add create election to the cli tool which accepts a manifest and key ceremony parameters in order to create a context.json file. There is room for improvement such as outputting constants.json and zipping to make an election package, as well as accepting a key ceremony json object so that we do not have to pass in all of the parameters on the command line. (see: #312 )

### Testing
run the new command an verify that it completes without errors and outputs data

```sh
cd ./apps/electionguard-cli && dotnet run create-election --commitment=F2683C1CB465B0DA39ACF98A122A313C2CC068AC33572DF277844D1C6AA17C7C --manifest=./path/to/manifest.json --guardians=1 --quorum=1 --publicKey=C95021CDDD663ABB5DED360F358D3E43D0C1F63D11FE95EBAB8D0735950DDE007DA312B0B11E81D15D84A95C5E89F1998F071BD6D29052496A6300D13551E562DDFE84BFE5BF5E20AA2EF94AF17FAA83D3924DE0FCE65556F4B65E52C368FBE55F390E9694172AE1B7D0D52FCCDE97DD30DA3FFF74846839763B8A26568A6BF31D21A4B8B2A49DF52860C555D2208E93BFCD66051AA8A91B473C29D6E1A06A80FF8AD005F41DB867124D6C37D5E0794A1EAB1EDBA1A09D86D85A12DAC817084288CB462FD917419F24EB01EF8CF7DB2D44320309CC2E9780DB93D5FFB335B0B32BFC58EF42DA1031107965130CE5E752D13D5FFF06A5A30136B5696CE298F18882261086D883F84E0B4D0614C80DC26E53988859199F7C9CAAD82E27D6D634E08C2675EA64287E7EAAB00B88ED97F4C5EA2BF1EF9FB5419E97C0F688B7ECEB6F1338E5E9A01D25B4E98BBD8FFEEF36748BB7C26927AF3746D6C5958B2F8E4E83E57B38CC61C505060D962BB7BDB3BE7B5A07BF68ACE363A85884F8246F5CBC6594703FDEC2EA57E7E8450F7D42408290A8BEF91D7AC11415CAD398D630AD289F3947F2ED3AF3F82FBD6AE1734BFEE62D7F14EEC0BAEE42F4C3AE17DB74D97892C51FBC59B3C5992E96996668A4E1B21D670EB65479FA1F83673C3155C26FF22B9E1F4665BE9D0C948742310517A7AC5209D1F6703314CE17D7504A0369D6E28D --out=./path/to/output
```
