### PR TITLE
Switched to use Newtonsoft instead of Microsoft JSON lib

### DIFF
--- a/src/electionguard-ui/ElectionGuard.UI/Helpers/ElectionRecordGenerator.cs
+++ b/src/electionguard-ui/ElectionGuard.UI/Helpers/ElectionRecordGenerator.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO.Compression;
 using System.Text.Json;
 using MongoDB.Driver;
+using Newtonsoft.Json;
+
 
 namespace ElectionGuard.UI.Helpers;
 
@@ -72,7 +74,7 @@ public static class ElectionRecordGenerator
         var guardians = await guardianPublicKeyService.GetAllByKeyCeremonyIdAsync(keyCeremonyId);
         foreach (var guardian in guardians)
         {
-            await File.WriteAllTextAsync(Path.Combine(guardianFolder, $"{GUARDIAN_PREFIX}{guardian.GuardianId}.json"), JsonSerializer.Serialize(guardian.PublicKey));
+            await File.WriteAllTextAsync(Path.Combine(guardianFolder, $"{GUARDIAN_PREFIX}{guardian.GuardianId}.json"), JsonConvert.SerializeObject(guardian.PublicKey));
         }
     }
 


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
Fixes #___

### Description
Switched to use Newtonsoft instead of Microsoft JSON lib

### Testing
Create an election package from a tally and then export it.  The guardian will be serialied with NewtonSoftware code instead of the Microsoft.Text.Json library
